### PR TITLE
Update typo for Seer in constants

### DIFF
--- a/src/constants/choices.const.js
+++ b/src/constants/choices.const.js
@@ -23,7 +23,7 @@ exports.class = {
   6: 'monk',
   7: 'pirate',
   8: 'berserker',
-  9: 'sheer',
+  9: 'seer',
   16: 'paladin',
   17: 'darkKnight',
   18: 'summoner',


### PR DESCRIPTION
I found a typo where `sheer` should be `seer`.